### PR TITLE
Add optional KML/KMZ exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ This Python package extracts geographical coordinates from Telegram messages, su
   - Message metadata (ID, date, text, source)
   - Direct links to the original messages
   - Latitude and longitude in decimal format
-  - CSV export for easy analysis and mapping
+  - CSV export for easy analysis
+  - Optional KML/KMZ export for direct use in Google Earth and GIS tools
 
 - **Configuration Options**:
   - Environment variables
@@ -100,13 +101,14 @@ For automated usage, you can use command-line arguments:
 
 ```bash
 # Search a specific channel
-python Scrape_Coordinates.py --mode channel --channel @channelname --output results.csv
+python Scrape_Coordinates.py --mode channel --channel @channelname --output results.csv --export-kml
 
-# Search all accessible chats
-python Scrape_Coordinates.py --mode all --output results.csv
+# Search all accessible chats and create a KMZ copy of the results
+python Scrape_Coordinates.py --mode all --output results.csv --export-kmz
 
-# Process a JSON export
-python Scrape_Coordinates.py --mode json --json-file export.json --post-link-base https://t.me/channelname/ --output results.csv
+# Process a JSON export and provide custom output filenames
+python Scrape_Coordinates.py --mode json --json-file export.json --post-link-base https://t.me/channelname/ \
+  --output results.csv --kml-output results/my_coordinates.kml --kmz-output results/my_coordinates.kmz
 ```
 
 ### Using as a Package
@@ -171,6 +173,12 @@ software. By default, files are placed in the `results/` directory (the folder
 is created automatically if it does not exist) and use the filename configured
 in `TELEGRAM_COORDINATES_CSV_FILE`.
 
+When the `--export-kml` or `--export-kmz` flags (or their corresponding
+`--kml-output` / `--kmz-output` paths) are provided, the scraper creates
+additional geospatial files alongside the CSV export. These files include the
+same metadata as the CSV and can be opened directly in mapping tools such as
+Google Earth, QGIS, or ArcGIS.
+
 | Column | Description |
 | --- | --- |
 | `Post ID` | Numeric identifier of the Telegram message. |
@@ -192,11 +200,10 @@ in `TELEGRAM_COORDINATES_CSV_FILE`.
 
 ### Google Earth
 
-1. Open Google Earth Pro
-2. Go to File > Import
-3. Select the CSV file
-4. Map the latitude and longitude columns
-5. Adjust display options
+1. Open Google Earth or Google Earth Pro
+2. Import the generated KML/KMZ file (or the CSV file if preferred)
+3. If importing CSV, map the latitude and longitude columns when prompted
+4. Adjust display options to style the placemarks
 
 ### GIS Tools
 

--- a/src/export.py
+++ b/src/export.py
@@ -1,34 +1,265 @@
 import os
 import csv
 import logging
+import zipfile
+from typing import Dict, List, Optional
+
+from xml.dom import minidom
+from xml.etree.ElementTree import Element, SubElement, tostring
+from xml.sax.saxutils import escape
+
+KML_NAMESPACE = "http://www.opengis.net/kml/2.2"
+LATITUDE_KEYS = ("latitude", "Latitude", "lat", "Lat")
+LONGITUDE_KEYS = ("longitude", "Longitude", "lon", "Lon", "lng", "Lng")
+NAME_FIELDS = (
+    "Message Text",
+    "message_content",
+    "Post Message",
+    "name",
+    "title",
+    "Post ID",
+    "message_id",
+)
+TEXT_FIELDS = ("Message Text", "message_content", "Post Message")
+DEFAULT_DESCRIPTION_FIELDS = (
+    "URL",
+    "message_source",
+    "Post Link",
+    "Date",
+    "Post Date",
+    "message_published_at",
+    "Channel/Group Username",
+    "Channel ID",
+    "Post ID",
+    "message_id",
+    "message_media_type",
+    "Media Type",
+    "Post Type",
+)
+TIME_FIELDS = ("Date", "message_published_at", "Post Date")
+
+
+def _ensure_directory(file_path: str) -> None:
+    """Create the parent directory for a file if it does not exist."""
+
+    directory = os.path.dirname(file_path)
+    if directory and not os.path.exists(directory):
+        os.makedirs(directory, exist_ok=True)
+
+
+def _choose_value(record: Dict[str, object], keys) -> Optional[str]:
+    """Return the first non-empty value for the provided keys."""
+
+    for key in keys:
+        if key in record:
+            value = record[key]
+            if value not in (None, ""):
+                return str(value)
+    return None
+
+
+def _truncate_text(text: str, max_length: int = 80) -> str:
+    """Truncate long strings for KML display purposes."""
+
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 3].rstrip() + "..."
+
+
+def _format_description(record: Dict[str, object], description_fields: Optional[List[str]]) -> str:
+    """Build a human-readable description string for KML."""
+
+    lines: List[str] = []
+
+    text_value = _choose_value(record, TEXT_FIELDS)
+    if text_value:
+        lines.append(text_value.strip())
+
+    fields_to_use = description_fields if description_fields else list(DEFAULT_DESCRIPTION_FIELDS)
+    seen_fields = set()
+
+    for field in fields_to_use:
+        if field in TEXT_FIELDS:
+            continue
+        value = record.get(field)
+        if value not in (None, ""):
+            lines.append(f"{field}: {value}")
+            seen_fields.add(field)
+
+    if not description_fields:
+        for key, value in record.items():
+            lower_key = key.lower()
+            if key in seen_fields or key in TEXT_FIELDS:
+                continue
+            if lower_key in ("latitude", "longitude"):
+                continue
+            if value in (None, ""):
+                continue
+            lines.append(f"{key}: {value}")
+
+    if not lines:
+        return ""
+
+    escaped = escape("\n".join(str(item) for item in lines))
+    return escaped.replace("\n", "&#10;")
+
+
+def _append_extended_data(placemark: Element, record: Dict[str, object]) -> None:
+    """Attach additional record fields as ExtendedData to the placemark."""
+
+    extended_data = SubElement(placemark, "ExtendedData")
+    added = False
+
+    for key, value in record.items():
+        lower_key = key.lower()
+        if lower_key in ("latitude", "longitude"):
+            continue
+        if value in (None, ""):
+            continue
+        data_element = SubElement(extended_data, "Data", name=str(key))
+        value_element = SubElement(data_element, "value")
+        value_element.text = str(value)
+        added = True
+
+    if not added:
+        placemark.remove(extended_data)
+
+
+def _render_kml(records: List[Dict[str, object]], document_name: str,
+                description_fields: Optional[List[str]] = None) -> bytes:
+    """Render records as a pretty-printed KML document."""
+
+    kml_root = Element("kml", xmlns=KML_NAMESPACE)
+    document = SubElement(kml_root, "Document")
+
+    if document_name:
+        name_element = SubElement(document, "name")
+        name_element.text = document_name
+
+    placemark_count = 0
+    for index, record in enumerate(records, start=1):
+        latitude = _choose_value(record, LATITUDE_KEYS)
+        longitude = _choose_value(record, LONGITUDE_KEYS)
+
+        if latitude is None or longitude is None:
+            continue
+
+        try:
+            lat_value = float(latitude)
+            lon_value = float(longitude)
+        except (TypeError, ValueError):
+            continue
+
+        placemark = SubElement(document, "Placemark")
+
+        name_value = _choose_value(record, NAME_FIELDS)
+        if name_value:
+            name = SubElement(placemark, "name")
+            name.text = _truncate_text(name_value.strip())
+        else:
+            name = SubElement(placemark, "name")
+            name.text = f"Coordinate {index}"
+
+        description_text = _format_description(record, description_fields)
+        if description_text:
+            description = SubElement(placemark, "description")
+            description.text = description_text
+
+        time_value = _choose_value(record, TIME_FIELDS)
+        if time_value:
+            timestamp = SubElement(placemark, "TimeStamp")
+            when = SubElement(timestamp, "when")
+            when.text = str(time_value)
+
+        point = SubElement(placemark, "Point")
+        coordinates = SubElement(point, "coordinates")
+        coordinates.text = f"{lon_value},{lat_value}"
+
+        _append_extended_data(placemark, record)
+        placemark_count += 1
+
+    if placemark_count == 0:
+        return b""
+
+    rough_string = tostring(kml_root, encoding="utf-8")
+    parsed = minidom.parseString(rough_string)
+    return parsed.toprettyxml(indent="  ", encoding="utf-8")
+
+
+def _rows_to_records(headers: List[str], rows: List[List[object]]) -> List[Dict[str, object]]:
+    """Convert CSV rows and headers into dictionaries."""
+
+    records: List[Dict[str, object]] = []
+    header_length = len(headers)
+
+    for row in rows:
+        if len(row) != header_length:
+            continue
+        record = {headers[i]: row[i] for i in range(header_length)}
+        records.append(record)
+
+    return records
 
 
 class CoordinatesWriter:
-    """CSV writer for coordinates data."""
+    """CSV writer for coordinates data with optional KML/KMZ export."""
 
-    def __init__(self, csv_file_path):
-        """
-        Initialize the coordinates writer.
+    def __init__(self, csv_file_path: str, kml_file_path: Optional[str] = None,
+                 kmz_file_path: Optional[str] = None, document_name: str = "Telegram Coordinates",
+                 description_fields: Optional[List[str]] = None):
+        """Initialize the coordinates writer.
 
         Args:
-            csv_file_path (str): Path to the CSV file
+            csv_file_path: Path to the CSV file.
+            kml_file_path: Optional path to write a KML export when the context is closed.
+            kmz_file_path: Optional path to write a KMZ export when the context is closed.
+            document_name: Title to use inside the generated KML/KMZ document.
+            description_fields: Optional list of fields to include in the placemark description.
         """
+
         self.csv_file_path = csv_file_path
-        # Ensure the directory exists
-        os.makedirs(os.path.dirname(csv_file_path) if os.path.dirname(csv_file_path) else '.', exist_ok=True)
+        _ensure_directory(csv_file_path)
         self.file_exists = os.path.isfile(csv_file_path)
         self.file = None
         self.writer = None
 
+        self.kml_file_path = kml_file_path
+        self.kmz_file_path = kmz_file_path
+        self.document_name = document_name
+        self.description_fields = description_fields
+
+        self.rows: Optional[List[List[object]]] = [] if (kml_file_path or kmz_file_path) else None
+        self.headers: Optional[List[str]] = None
+
+    def _load_existing_rows(self):
+        """Load existing CSV data into memory when additional exports are requested."""
+
+        if self.rows is None or not self.file_exists:
+            return
+
+        try:
+            with open(self.csv_file_path, 'r', newline='', encoding='utf-8') as existing_file:
+                reader = csv.reader(existing_file)
+                self.headers = next(reader, None)
+                if self.headers:
+                    for row in reader:
+                        self.rows.append(row)
+        except FileNotFoundError:
+            return
+        except Exception as exc:
+            logging.warning(f"Failed to preload existing CSV data for export: {exc}")
+
     def __enter__(self):
         """Context manager entry - open the CSV file."""
+
+        self._load_existing_rows()
+
         try:
             self.file = open(self.csv_file_path, 'a', newline='', encoding='utf-8')
-            self.writer = csv.writer(self.file)
+            csv_writer = csv.writer(self.file)
 
-            # Write header if file doesn't exist
             if not self.file_exists:
-                self.writer.writerow([
+                header = [
                     'Post ID',
                     'Channel ID',
                     'Channel/Group Username',
@@ -37,11 +268,15 @@ class CoordinatesWriter:
                     'URL',
                     'Latitude',
                     'Longitude'
-                ])
+                ]
+                csv_writer.writerow(header)
                 logging.info(f"Created new CSV file: {self.csv_file_path}")
+                if self.rows is not None:
+                    self.headers = header
             else:
                 logging.info(f"Appending to existing CSV file: {self.csv_file_path}")
 
+            self.writer = _CSVProxyWriter(csv_writer, self)
             return self.writer
 
         except Exception as e:
@@ -51,7 +286,8 @@ class CoordinatesWriter:
             raise
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """Context manager exit - close the CSV file."""
+        """Context manager exit - close the CSV file and trigger additional exports."""
+
         if self.file:
             self.file.close()
 
@@ -59,7 +295,47 @@ class CoordinatesWriter:
             logging.error(f"An error occurred while writing to CSV: {exc_val}")
             return False
 
+        self._export_additional_formats()
         return True
+
+    def _export_additional_formats(self):
+        """Export collected rows to any requested additional formats."""
+
+        if self.rows is None or not self.headers:
+            return
+
+        records = _rows_to_records(self.headers, self.rows)
+        if not records:
+            return
+
+        if self.kml_file_path:
+            save_records_to_kml(records, self.kml_file_path, self.document_name, self.description_fields)
+
+        if self.kmz_file_path:
+            save_records_to_kmz(records, self.kmz_file_path, self.document_name, self.description_fields)
+
+
+class _CSVProxyWriter:
+    """Proxy object that mirrors csv.writer while collecting written rows."""
+
+    def __init__(self, csv_writer, parent: CoordinatesWriter):
+        self._csv_writer = csv_writer
+        self._parent = parent
+
+    def writerow(self, row):
+        self._csv_writer.writerow(row)
+        if self._parent.rows is not None:
+            if self._parent.headers is None:
+                self._parent.headers = list(row)
+            else:
+                self._parent.rows.append(list(row))
+
+    def writerows(self, rows):
+        for row in rows:
+            self.writerow(row)
+
+    def __getattr__(self, item):
+        return getattr(self._csv_writer, item)
 
 
 def save_to_csv(data, csv_file_path, headers=None):
@@ -75,8 +351,7 @@ def save_to_csv(data, csv_file_path, headers=None):
         bool: True if successful, False otherwise
     """
     try:
-        # Ensure the directory exists
-        os.makedirs(os.path.dirname(csv_file_path) if os.path.dirname(csv_file_path) else '.', exist_ok=True)
+        _ensure_directory(csv_file_path)
 
         file_exists = os.path.isfile(csv_file_path)
 
@@ -95,3 +370,89 @@ def save_to_csv(data, csv_file_path, headers=None):
     except Exception as e:
         logging.error(f"Failed to write to CSV file: {e}")
         return False
+
+
+def save_records_to_kml(records: List[Dict[str, object]], kml_file_path: str,
+                        document_name: str = "Telegram Coordinates",
+                        description_fields: Optional[List[str]] = None) -> bool:
+    """Save a list of record dictionaries to a KML file."""
+
+    if not records:
+        logging.info(f"No records available for KML export: {kml_file_path}")
+        return False
+
+    try:
+        _ensure_directory(kml_file_path)
+        kml_bytes = _render_kml(records, document_name, description_fields)
+        if not kml_bytes:
+            logging.info(f"No valid coordinates to export to KML: {kml_file_path}")
+            return False
+
+        with open(kml_file_path, 'wb') as kml_file:
+            kml_file.write(kml_bytes)
+
+        logging.info(f"Data saved to KML file: {kml_file_path}")
+        return True
+    except Exception as e:
+        logging.error(f"Failed to write to KML file: {e}")
+        return False
+
+
+def save_records_to_kmz(records: List[Dict[str, object]], kmz_file_path: str,
+                        document_name: str = "Telegram Coordinates",
+                        description_fields: Optional[List[str]] = None) -> bool:
+    """Save a list of record dictionaries to a KMZ archive."""
+
+    if not records:
+        logging.info(f"No records available for KMZ export: {kmz_file_path}")
+        return False
+
+    try:
+        _ensure_directory(kmz_file_path)
+        kml_bytes = _render_kml(records, document_name, description_fields)
+        if not kml_bytes:
+            logging.info(f"No valid coordinates to export to KMZ: {kmz_file_path}")
+            return False
+
+        with zipfile.ZipFile(kmz_file_path, 'w', compression=zipfile.ZIP_DEFLATED) as kmz:
+            kmz.writestr('doc.kml', kml_bytes)
+
+        logging.info(f"Data saved to KMZ file: {kmz_file_path}")
+        return True
+    except Exception as e:
+        logging.error(f"Failed to write to KMZ file: {e}")
+        return False
+
+
+def save_dataframe_to_kml(df, kml_file_path: str, document_name: str = "Telegram Coordinates",
+                          description_fields: Optional[List[str]] = None) -> bool:
+    """Save a pandas DataFrame to a KML file."""
+
+    if df is None or getattr(df, 'empty', True):
+        logging.info(f"No data available for KML export: {kml_file_path}")
+        return False
+
+    try:
+        records = df.to_dict(orient='records')
+    except AttributeError as exc:
+        logging.error(f"Data object does not support DataFrame-like export: {exc}")
+        return False
+
+    return save_records_to_kml(records, kml_file_path, document_name, description_fields)
+
+
+def save_dataframe_to_kmz(df, kmz_file_path: str, document_name: str = "Telegram Coordinates",
+                          description_fields: Optional[List[str]] = None) -> bool:
+    """Save a pandas DataFrame to a KMZ file."""
+
+    if df is None or getattr(df, 'empty', True):
+        logging.info(f"No data available for KMZ export: {kmz_file_path}")
+        return False
+
+    try:
+        records = df.to_dict(orient='records')
+    except AttributeError as exc:
+        logging.error(f"Data object does not support DataFrame-like export: {exc}")
+        return False
+
+    return save_records_to_kmz(records, kmz_file_path, document_name, description_fields)


### PR DESCRIPTION
## Summary
- add reusable KML/KMZ export helpers and extend `CoordinatesWriter` to capture rows for additional formats
- allow the channel scraping entry points to write optional KML and KMZ files via new parameters and CLI flags
- refresh documentation to describe the additional export options and usage examples

## Testing
- python -m compileall src Scrape_Coordinates.py

------
https://chatgpt.com/codex/tasks/task_e_68ccf9bdbcc483248c9535704dd29562